### PR TITLE
Soften msgpack dependency

### DIFF
--- a/transit-ruby.gemspec
+++ b/transit-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   else
     spec.files    = files - jruby_files
     spec.add_dependency "oj",                             "~> 2.18"
-    spec.add_dependency "msgpack",                        "~> 1.1.0"
+    spec.add_dependency "msgpack",                        "~> 1.1"
     spec.add_development_dependency "yard",               "~> 0.9.11"
     private_key_path = File.expand_path(File.join(ENV['HOME'], '.gem', 'transit-ruby', 'gem-private_key.pem'))
     public_key_path  = File.expand_path(File.join(ENV['HOME'], '.gem', 'transit-ruby', 'gem-public_cert.pem'))


### PR DESCRIPTION
This will allow to bump msgpack from current 1.1.0 to 1.3.3.
It may help with https://github.com/Shopify/bootsnap/issues/87#issuecomment-378022253.