### PR TITLE
Relax msgpack dependency for Ruby 3

### DIFF
--- a/transit-ruby.gemspec
+++ b/transit-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   else
     spec.files    = files - jruby_files
     spec.add_dependency "oj",                             "~> 3.10", ">= 3.10.16"
-    spec.add_dependency "msgpack",                        "~> 1.1"
+    spec.add_dependency "msgpack",                        ">= 1.1.0"
     spec.add_development_dependency "yard",               "~> 0.9.11"
     private_key_path = File.expand_path(File.join(ENV['HOME'], '.gem', 'transit-ruby', 'gem-private_key.pem'))
     public_key_path  = File.expand_path(File.join(ENV['HOME'], '.gem', 'transit-ruby', 'gem-public_cert.pem'))


### PR DESCRIPTION
In the process of upgrading an application to Ruby 3, I found that a newer version of `msgpack` is required (indirectly through [bootsnap](https://github.com/Shopify/bootsnap/blame/main/bootsnap.gemspec#L41)). This conflicts with the dependency definition in transit-ruby, so I would like to relax the msgpack dependency even further than previously done [here](https://github.com/nashbridges/transit-ruby/pull/3).

Note: I don't know if you're accepting Pull Requests at this point - I got the idea of using your fork from this comment: https://github.com/cognitect/transit-ruby/issues/29#issuecomment-892969143